### PR TITLE
Refactor: Remove unused options and update styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A customizable, real-time map and data overlay for live streaming, designed to w
 
 -   **Live Map**: Shows your current location and path on a map.
 -   **Speedometer**: Displays your current speed in km/h or mph.
--   **Direction Display**: Shows your direction of travel with a cardinal abbreviation (e.g., N, NE) and a rotating arrow.
+-   **Direction Display**: Shows your direction of travel with a cardinal abbreviation (e.g., N, NE).
 -   **Location Name**: Shows your current city, state, and country.
 -   **Weather Display**: When you are stationary, the overlay can show the current weather conditions.
 -   **Customizable**: You can customize the overlay's appearance and features using URL parameters.
@@ -24,14 +24,10 @@ For example: `https://kickis.fun?weather=false&time=false&unit=mph`
 
 ### Customization Parameters
 
--   `weather`: Set to `false` to disable the weather display when stationary. (Default: `true`)
 -   `time`: Set to `false` to disable the rotation between location name and date/time. (Default: `true`)
 -   `unit`: Set to `mph` to display speed in miles per hour. (Default: `kmh`)
 -   `powersave`: Set to `true` to reduce battery consumption by lowering GPS accuracy and update frequency. (Default: `false`)
 -   `datasaver`: Set to `true` to reduce data usage by disabling location name and weather lookups. (Default: `false`)
--   `map`: Set to `false` to disable the map display entirely, which significantly reduces data usage. (Default: `true`)
--   `top`, `bottom`, `left`, `right`: Position the overlay on the screen. For example, `top=10px&left=10px`.
--   `width`, `height`: Set the size of the overlay. For example, `width=350px&height=280px`.
 
 ## Credits
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
                 <div id="speed-unit">km/h</div>
             </div>
             <div id="direction-display">
-                <div id="direction-arrow">↑</div>
                 <div id="direction-abbr">N</div>
             </div>
             <div id="location-display">

--- a/script.js
+++ b/script.js
@@ -21,12 +21,10 @@ class IRLMapOverlay {
         this.currentTimezone = null;
         
         // Customization parameters from URL, initialized with defaults
-        this.showWeather = true; 
         this.rotateDateTime = true;
         this.speedUnit = 'kmh';
         this.powerSave = false;
         this.dataSaver = false;
-        this.mapEnabled = true;
         this.trackingState = 'high';
         
         // Speed calculation settings
@@ -45,7 +43,6 @@ class IRLMapOverlay {
         this.displayRotationTime = 30000; // 30 seconds
         
         this.parseUrlParameters(); // Parse URL parameters first
-        this.applyOverlayStyles(); // Apply dynamic styles based on parsed parameters
 
         // FIX: Immediately set the initial speed unit display based on parsed parameters
         const speedUnitElement = document.getElementById('speed-unit');
@@ -72,9 +69,6 @@ class IRLMapOverlay {
         const urlParams = new URLSearchParams(window.location.search);
         
         // Boolean flags
-        if (urlParams.has('weather')) {
-            this.showWeather = urlParams.get('weather').toLowerCase() === 'true';
-        }
         if (urlParams.has('time')) { // 'time' refers to the date/time rotation
             this.rotateDateTime = urlParams.get('time').toLowerCase() === 'true';
         }
@@ -83,9 +77,6 @@ class IRLMapOverlay {
         }
         if (urlParams.has('datasaver')) {
             this.dataSaver = urlParams.get('datasaver').toLowerCase() === 'true';
-        }
-        if (urlParams.has('map')) {
-            this.mapEnabled = urlParams.get('map').toLowerCase() === 'true';
         }
         
         // Speed unit
@@ -99,44 +90,7 @@ class IRLMapOverlay {
         }
     }
 
-    // Function to apply dynamic styles from URL parameters
-    applyOverlayStyles() {
-        const overlayContainer = document.getElementById('overlay-container');
-        if (overlayContainer) {
-            const urlParams = new URLSearchParams(window.location.search);
-
-            // Positioning (prioritize top/left if both specified, otherwise respect individual settings)
-            if (urlParams.has('top')) {
-                overlayContainer.style.top = urlParams.get('top');
-                overlayContainer.style.bottom = 'auto'; // Clear conflicting property
-            } else if (urlParams.has('bottom')) {
-                overlayContainer.style.bottom = urlParams.get('bottom');
-                overlayContainer.style.top = 'auto'; // Clear conflicting property
-            }
-
-            if (urlParams.has('right')) {
-                overlayContainer.style.right = urlParams.get('right');
-                overlayContainer.style.left = 'auto'; // Clear conflicting property
-            } else if (urlParams.has('left')) {
-                overlayContainer.style.left = urlParams.get('left');
-                overlayContainer.style.right = 'auto'; // Clear conflicting property
-            }
-
-            // Size
-            if (urlParams.has('width')) {
-                overlayContainer.style.width = urlParams.get('width');
-            }
-            if (urlParams.has('height')) {
-                overlayContainer.style.height = urlParams.get('height');
-            }
-        }
-    }
-
     initMap() {
-        if (!this.mapEnabled) {
-            document.getElementById('map').style.display = 'none';
-            return;
-        }
         this.map = L.map('map', {
             zoomControl: false,
             attributionControl: false,
@@ -371,12 +325,12 @@ class IRLMapOverlay {
             this.stationaryStartTime = null;
         }
 
-        // Only update weather if showWeather is true and conditions are met
-        if (this.showWeather && this.isStationary && this.stationaryStartTime && 
+        // Only update weather if conditions are met
+        if (this.isStationary && this.stationaryStartTime &&
             (timestamp - this.stationaryStartTime) > this.stationaryDelay) {
-            
-            const shouldUpdateWeather = 
-                !this.currentWeather || 
+
+            const shouldUpdateWeather =
+                !this.currentWeather ||
                 (timestamp - this.lastWeatherUpdate) > this.weatherUpdateInterval;
 
             if (shouldUpdateWeather) {
@@ -636,9 +590,9 @@ class IRLMapOverlay {
         const speedElement = document.getElementById('speed-value');
         const speedUnit = document.getElementById('speed-unit');
         
-        // Check if we should show weather instead of speed (only if showWeather is enabled)
-        const shouldShowWeather = this.showWeather && displaySpeed === 0 && this.isStationary && 
-                                 this.stationaryStartTime && 
+        // Check if we should show weather instead of speed
+        const shouldShowWeather = displaySpeed === 0 && this.isStationary &&
+                                 this.stationaryStartTime &&
                                  (Date.now() - this.stationaryStartTime) > this.stationaryDelay &&
                                  this.currentWeather;
 

--- a/style.css
+++ b/style.css
@@ -120,8 +120,10 @@ body {
 
 #location-name {
     color: #ffffff;
-    font-weight: 600;
+    font-weight: 700;
+    font-size: 24px;
     transition: all 0.5s ease-in-out;
+    width: 100%;
 }
 
 /* DateTime display styling */
@@ -175,12 +177,6 @@ body {
     justify-content: center;
 }
 
-#location-name {
-    color: #ffffff;
-    font-weight: 600;
-    transition: all 0.5s ease-in-out;
-    width: 100%;
-}
 
 /* Kick.com inspired speed color coding */
 .speed-stationary { 
@@ -253,20 +249,12 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
     opacity: 0; /* Initially hidden */
     transition: opacity 0.5s ease-in-out;
 }
 
 #direction-display.visible {
     opacity: 1;
-}
-
-#direction-arrow {
-    font-size: 22px;
-    line-height: 1;
-    color: #53fc18;
-    transition: transform 0.5s ease-in-out;
 }
 
 #direction-abbr {


### PR DESCRIPTION
This commit removes several URL parameters that are no longer needed:
- `weather`
- `map`
- `top`, `bottom`, `left`, `right`
- `width`, `height`

The styling has also been updated to:
- Make the location/weather text 24px and bold.
- Remove the direction arrow, keeping only the abbreviation.

The README has been updated to reflect these changes.